### PR TITLE
Fix content length header

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,27 @@ The asterisk must be the last character of the key, so you **must** put the $uri
 
 
 
+Purging multiple cache entries with the same cache key
+======================================================
+Caching requests that use the "Vary" header may result in multiple cache
+entries with the same cache key. For example, when using the request header
+"Vary: Accept-Encoding", a separate cache entry (with different file hash)
+will be stored for each content encoding (like compressed or uncompressed),
+but they will all have the exact same cache key.
+
+Trying to purge such cached content will fail unless both the "Vary" header
+is specified in the purge request, plus all headers as listed in the "Vary"
+header, with the exact same values as used when the request was cached.
+
+To be able to purge *all* pages with the same cache key, specify the key with
+a "$" at the end, like this:
+
+    curl -X PURGE /page$
+
+This will purge all content with the exact key "/page" from the cache.
+
+
+
 Sample configuration (same location syntax)
 ===========================================
     http {

--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ uwsgi_cache_purge
 
 Sets area and key used for purging selected pages from `uWSGI`'s cache.
 
+Configuration directives (Optional)
+===================================================
+
+cache_purge_response_type
+-----------------
+* **syntax**: `cache_purge_response_type html|json|xml|text`
+* **default**: `html`
+* **context**: `http`, `server`, `location`
+
+Sets a response type of purging result.
+
 
 Sample configuration (same location syntax)
 ===========================================
@@ -125,6 +136,61 @@ Sample configuration (separate location syntax)
             }
         }
     }
+
+Sample configuration (Optional)
+===============================================
+    http {
+        proxy_cache_path  /tmp/cache  keys_zone=tmpcache:10m;
+
+        cache_purge_response_type text;
+
+        server {
+
+            cache_purge_response_type json;
+
+            location / { //json
+                proxy_pass         http://127.0.0.1:8000;
+                proxy_cache        tmpcache;
+                proxy_cache_key    $uri$is_args$args;
+            }
+
+            location ~ /purge(/.*) { //xml
+                allow              127.0.0.1;
+                deny               all;
+                proxy_cache_purge  tmpcache $1$is_args$args;
+                cache_purge_response_type xml;
+            }
+
+            location ~ /purge2(/.*) { // json
+                allow              127.0.0.1;
+                deny               all;
+                proxy_cache_purge  tmpcache $1$is_args$args;
+            }
+        }
+
+        server {
+
+            location / { //text
+                proxy_pass         http://127.0.0.1:8000;
+                proxy_cache        tmpcache;
+                proxy_cache_key    $uri$is_args$args;
+            }
+
+            location ~ /purge(/.*) { //text
+                allow              127.0.0.1;
+                deny               all;
+                proxy_cache_purge  tmpcache $1$is_args$args;
+            }
+
+            location ~ /purge2(/.*) { /html/
+                allow              127.0.0.1;
+                deny               all;
+                proxy_cache_purge  tmpcache $1$is_args$args;
+                cache_purge_response_type html;
+            }
+        }
+    }
+
 
 
 Testing

--- a/README.md
+++ b/README.md
@@ -177,20 +177,20 @@ Sample configuration (Optional)
 
             cache_purge_response_type json;
 
-            location / { //json
+            location / { #json
                 proxy_pass         http://127.0.0.1:8000;
                 proxy_cache        tmpcache;
                 proxy_cache_key    $uri$is_args$args;
             }
 
-            location ~ /purge(/.*) { //xml
+            location ~ /purge(/.*) { #xml
                 allow              127.0.0.1;
                 deny               all;
                 proxy_cache_purge  tmpcache $1$is_args$args;
                 cache_purge_response_type xml;
             }
 
-            location ~ /purge2(/.*) { // json
+            location ~ /purge2(/.*) { # json
                 allow              127.0.0.1;
                 deny               all;
                 proxy_cache_purge  tmpcache $1$is_args$args;
@@ -199,19 +199,19 @@ Sample configuration (Optional)
 
         server {
 
-            location / { //text
+            location / { #text
                 proxy_pass         http://127.0.0.1:8000;
                 proxy_cache        tmpcache;
                 proxy_cache_key    $uri$is_args$args;
             }
 
-            location ~ /purge(/.*) { //text
+            location ~ /purge(/.*) { #text
                 allow              127.0.0.1;
                 deny               all;
                 proxy_cache_purge  tmpcache $1$is_args$args;
             }
 
-            location ~ /purge2(/.*) { /html/
+            location ~ /purge2(/.*) { #html
                 allow              127.0.0.1;
                 deny               all;
                 proxy_cache_purge  tmpcache $1$is_args$args;

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -1249,9 +1249,11 @@ ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *pa
     } else {
         ngx_file_t file;
 
+        ngx_memzero(&file, sizeof(ngx_file_t));
         file.offset = file.sys_offset = 0;
         file.fd = ngx_open_file(path->data, NGX_FILE_RDONLY, NGX_FILE_OPEN,
                                 NGX_FILE_DEFAULT_ACCESS);
+        file.log = ctx->log;
 
         /* I don't know if it's a good idea to use the ngx_cycle pool for this,
            but the request is not available here */

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -1531,7 +1531,7 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r) {
     r->headers_out.content_type.len = resp_ct_size - 1;
     r->headers_out.content_type.data = (u_char *) resp_ct;
 
-    resp_tmpl_len = body_len + key[0].len + r->cache->file.name.len ;
+    resp_tmpl_len = body_len + key[0].len;
 
     buf = ngx_pcalloc(r->pool, resp_tmpl_len);
     if (buf == NULL) {
@@ -1539,12 +1539,12 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r) {
     }
 
     //p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, r->cache->file.name.data);
-    p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, buf_keydata);
+    p = ngx_snprintf(buf, resp_tmpl_len, resp_body, buf_keydata, buf_keydata);
     if (p == NULL) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    len = body_len + key[0].len + r->cache->file.name.len;
+    len = body_len + key[0].len;
 
     r->headers_out.status = NGX_HTTP_OK;
     r->headers_out.content_length_n = len;

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -53,7 +53,7 @@ static size_t ngx_http_cache_purge_content_type_xml_size = sizeof(ngx_http_cache
 static size_t ngx_http_cache_purge_content_type_text_size = sizeof(ngx_http_cache_purge_content_type_text);
 
 static const char ngx_http_cache_purge_body_templ_json[] = "{\"Key\": \"%s\"}";
-static const char ngx_http_cache_purge_body_templ_html[] = "<html><head><title>Successful purge</title></head><body bgcolor=\"white\"><center><h1>Successful purge</h1><br>Key : %s</center></body></html>";
+static const char ngx_http_cache_purge_body_templ_html[] = "<html><head><title>Successful purge</title></head><body bgcolor=\"white\"><center><h1>Successful purge</h1><p>Key : %s</p></center></body></html>";
 static const char ngx_http_cache_purge_body_templ_xml[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><status><Key><![CDATA[%s]]></Key></status>";
 static const char ngx_http_cache_purge_body_templ_text[] = "Key:%s\n";
 
@@ -1527,7 +1527,7 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r) {
             break;
     }
 
-    body_len = resp_body_size - 4 - 1;
+    body_len = resp_body_size - 2 - 1;
     r->headers_out.content_type.len = resp_ct_size - 1;
     r->headers_out.content_type.data = (u_char *) resp_ct;
 
@@ -1537,7 +1537,6 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r) {
     if (buf == NULL) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
-
 
     //p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, r->cache->file.name.data);
     p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, buf_keydata);

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -387,6 +387,7 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->fastcgi.enable = 0;
+    cplcf->conf = &cplcf->fastcgi;
     clcf->handler = ngx_http_fastcgi_cache_purge_handler;
 
     return NGX_CONF_OK;
@@ -673,6 +674,7 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->proxy.enable = 0;
+    cplcf->conf = &cplcf->proxy;
     clcf->handler = ngx_http_proxy_cache_purge_handler;
 
     return NGX_CONF_OK;
@@ -897,6 +899,7 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->scgi.enable = 0;
+    cplcf->conf = &cplcf->scgi;
     clcf->handler = ngx_http_scgi_cache_purge_handler;
 
     return NGX_CONF_OK;
@@ -1144,6 +1147,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->uwsgi.enable = 0;
+    cplcf->conf = &cplcf->uwsgi;
     clcf->handler = ngx_http_uwsgi_cache_purge_handler;
 
     return NGX_CONF_OK;

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -52,10 +52,10 @@ static size_t ngx_http_cache_purge_content_type_html_size = sizeof(ngx_http_cach
 static size_t ngx_http_cache_purge_content_type_xml_size = sizeof(ngx_http_cache_purge_content_type_xml);
 static size_t ngx_http_cache_purge_content_type_text_size = sizeof(ngx_http_cache_purge_content_type_text);
 
-static const char ngx_http_cache_purge_body_templ_json[] = "{\"Key\": \"%s\",\"Path\": \"%s\"}";
-static const char ngx_http_cache_purge_body_templ_html[] = "<html><head><title>Successful purge</title></head><body bgcolor=\"white\"><center><h1>Successful purge</h1><br>Key : %s<br>Path : %s</center></body></html>";
-static const char ngx_http_cache_purge_body_templ_xml[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><status><Key><![CDATA[%s]]></Key><Path><![CDATA[%s]]></Path></status>";
-static const char ngx_http_cache_purge_body_templ_text[] = "Key:%s\nPath:%s\n";
+static const char ngx_http_cache_purge_body_templ_json[] = "{\"Key\": \"%s\"}";
+static const char ngx_http_cache_purge_body_templ_html[] = "<html><head><title>Successful purge</title></head><body bgcolor=\"white\"><center><h1>Successful purge</h1><br>Key : %s</center></body></html>";
+static const char ngx_http_cache_purge_body_templ_xml[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><status><Key><![CDATA[%s]]></Key></status>";
+static const char ngx_http_cache_purge_body_templ_text[] = "Key:%s\n";
 
 static size_t ngx_http_cache_purge_body_templ_json_size = sizeof(ngx_http_cache_purge_body_templ_json);
 static size_t ngx_http_cache_purge_body_templ_html_size = sizeof(ngx_http_cache_purge_body_templ_html);
@@ -1538,7 +1538,9 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, r->cache->file.name.data);
+
+    //p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, r->cache->file.name.data);
+    p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, buf_keydata);
     if (p == NULL) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
@@ -1571,7 +1573,6 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r) {
     if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
         return rc;
     }
-
 
     return ngx_http_output_filter(r, &out);
 }

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -37,6 +37,30 @@
 #error This module cannot be build against an unknown nginx version.
 #endif
 
+#define NGX_REPONSE_TYPE_HTML 1
+#define NGX_REPONSE_TYPE_XML  2
+#define NGX_REPONSE_TYPE_JSON 3
+#define NGX_REPONSE_TYPE_TEXT 4
+
+static const char ngx_http_cache_purge_content_type_json[] = "application/json";
+static const char ngx_http_cache_purge_content_type_html[] = "text/html";
+static const char ngx_http_cache_purge_content_type_xml[]  = "text/xml";
+static const char ngx_http_cache_purge_content_type_text[] = "text/plain";
+
+static size_t ngx_http_cache_purge_content_type_json_size = sizeof(ngx_http_cache_purge_content_type_json);
+static size_t ngx_http_cache_purge_content_type_html_size = sizeof(ngx_http_cache_purge_content_type_html);
+static size_t ngx_http_cache_purge_content_type_xml_size = sizeof(ngx_http_cache_purge_content_type_xml);
+static size_t ngx_http_cache_purge_content_type_text_size = sizeof(ngx_http_cache_purge_content_type_text);
+
+static const char ngx_http_cache_purge_body_templ_json[] = "{\"Key\": \"%s\",\"Path\": \"%s\"}";
+static const char ngx_http_cache_purge_body_templ_html[] = "<html><head><title>Successful purge</title></head><body bgcolor=\"white\"><center><h1>Successful purge</h1><br>Key : %s<br>Path : %s</center></body></html>";
+static const char ngx_http_cache_purge_body_templ_xml[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><status><Key><![CDATA[%s]]></Key><Path><![CDATA[%s]]></Path></status>";
+static const char ngx_http_cache_purge_body_templ_text[] = "Key:%s\nPath:%s\n";
+
+static size_t ngx_http_cache_purge_body_templ_json_size = sizeof(ngx_http_cache_purge_body_templ_json);
+static size_t ngx_http_cache_purge_body_templ_html_size = sizeof(ngx_http_cache_purge_body_templ_html);
+static size_t ngx_http_cache_purge_body_templ_xml_size = sizeof(ngx_http_cache_purge_body_templ_xml);
+static size_t ngx_http_cache_purge_body_templ_text_size = sizeof(ngx_http_cache_purge_body_templ_text);
 
 #if (NGX_HTTP_CACHE)
 
@@ -64,6 +88,8 @@ typedef struct {
     ngx_http_cache_purge_conf_t  *conf;
     ngx_http_handler_pt           handler;
     ngx_http_handler_pt           original_handler;
+
+    ngx_uint_t                    resptype; /* response content-type */
 } ngx_http_cache_purge_loc_conf_t;
 
 # if (NGX_HTTP_FASTCGI)
@@ -89,6 +115,9 @@ char       *ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf,
                 ngx_command_t *cmd, void *conf);
 ngx_int_t   ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r);
 # endif /* NGX_HTTP_UWSGI */
+
+char        *ngx_http_cache_purge_response_type_conf(ngx_conf_t *cf, 
+                ngx_command_t *cmd, void *conf);
 
 ngx_int_t   ngx_http_cache_purge_access_handler(ngx_http_request_t *r);
 ngx_int_t   ngx_http_cache_purge_access(ngx_array_t *a, ngx_array_t *a6,
@@ -150,7 +179,14 @@ static ngx_command_t  ngx_http_cache_purge_module_commands[] = {
       NULL },
 # endif /* NGX_HTTP_UWSGI */
 
-      ngx_null_command
+    { ngx_string("cache_purge_response_type"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_http_cache_purge_response_type_conf,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+    ngx_null_command
 };
 
 static ngx_http_module_t  ngx_http_cache_purge_module_ctx = {
@@ -181,20 +217,6 @@ ngx_module_t  ngx_http_cache_purge_module = {
     NULL,                                  /* exit master */
     NGX_MODULE_V1_PADDING
 };
-
-static char ngx_http_cache_purge_success_page_top[] =
-"<html>" CRLF
-"<head><title>Successful purge</title></head>" CRLF
-"<body bgcolor=\"white\">" CRLF
-"<center><h1>Successful purge</h1>" CRLF
-;
-
-static char ngx_http_cache_purge_success_page_tail[] =
-CRLF "</center>" CRLF
-"<hr><center>" NGINX_VER "</center>" CRLF
-"</body>" CRLF
-"</html>" CRLF
-;
 
 # if (NGX_HTTP_FASTCGI)
 extern ngx_module_t  ngx_http_fastcgi_module;
@@ -1095,6 +1117,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
+
 ngx_int_t
 ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r)
 {
@@ -1143,6 +1166,56 @@ ngx_http_uwsgi_cache_purge_handler(ngx_http_request_t *r)
     return NGX_DONE;
 }
 # endif /* NGX_HTTP_UWSGI */
+
+
+char *
+ngx_http_cache_purge_response_type_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_cache_purge_loc_conf_t   *cplcf;
+    ngx_str_t                         *value;
+
+    cplcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_cache_purge_module);
+
+    /* check for duplicates / collisions */
+    if (cplcf->resptype != NGX_CONF_UNSET_UINT && cf->cmd_type == NGX_HTTP_LOC_CONF )  {
+        return "is duplicate";
+    }
+
+    /* sanity check */
+    if (cf->args->nelts < 2) {
+        return "is invalid paramter, ex) cache_purge_response_type (html|json|xml|text)";
+    }
+
+    if (cf->args->nelts > 2 ) {
+        return "is required only 1 option, ex) cache_purge_response_type (html|json|xml|text)";
+    }
+
+    value = cf->args->elts;
+
+    if (ngx_strcmp(value[1].data, "html") != 0 && ngx_strcmp(value[1].data, "json") != 0 
+        && ngx_strcmp(value[1].data, "xml") != 0 && ngx_strcmp(value[1].data, "text") != 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid parameter \"%V\", expected"
+                           " \"(html|json|xml|text)\" keyword", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    if (cf->cmd_type == NGX_HTTP_MODULE) {
+        return "(separate server or location syntax) is not allowed here";
+    }
+
+    if (ngx_strcmp(value[1].data, "html") == 0) {
+        cplcf->resptype = NGX_REPONSE_TYPE_HTML;
+    } else if (ngx_strcmp(value[1].data, "xml") == 0) {
+        cplcf->resptype = NGX_REPONSE_TYPE_XML;
+    } else if (ngx_strcmp(value[1].data, "json") == 0) {
+        cplcf->resptype = NGX_REPONSE_TYPE_JSON;
+    } else if (ngx_strcmp(value[1].data, "text") == 0) {
+        cplcf->resptype = NGX_REPONSE_TYPE_TEXT;
+    }
+
+    return NGX_CONF_OK;
+}
 
 ngx_int_t
 ngx_http_cache_purge_access_handler(ngx_http_request_t *r)
@@ -1256,16 +1329,82 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r)
     ngx_str_t    *key;
     ngx_int_t     rc;
     size_t        len;
+    
+    size_t body_len;
+    size_t resp_tmpl_len;
+    u_char *buf;
+    u_char *buf_keydata;
+    u_char *p;
+    const char *resp_ct;
+    size_t resp_ct_size;
+    const char *resp_body;
+    size_t resp_body_size;
+
+    ngx_http_cache_purge_loc_conf_t   *cplcf;
+    cplcf = ngx_http_get_module_loc_conf(r, ngx_http_cache_purge_module);
 
     key = r->cache->keys.elts;
 
-    len = sizeof(ngx_http_cache_purge_success_page_top) - 1
-          + sizeof(ngx_http_cache_purge_success_page_tail) - 1
-          + sizeof("<br>Key : ") - 1 + sizeof(CRLF "<br>Path: ") - 1
-          + key[0].len + r->cache->file.name.len;
+    buf_keydata = ngx_pcalloc(r->pool, key[0].len+1);
+    if (buf_keydata == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
 
-    r->headers_out.content_type.len = sizeof("text/html") - 1;
-    r->headers_out.content_type.data = (u_char *) "text/html";
+    p = ngx_cpymem(buf_keydata, key[0].data, key[0].len);
+    if (p == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    switch(cplcf->resptype) {
+
+        case NGX_REPONSE_TYPE_JSON:
+            resp_ct = ngx_http_cache_purge_content_type_json;
+            resp_ct_size = ngx_http_cache_purge_content_type_json_size;
+            resp_body = ngx_http_cache_purge_body_templ_json;
+            resp_body_size = ngx_http_cache_purge_body_templ_json_size;
+            break;
+
+        case NGX_REPONSE_TYPE_XML:
+            resp_ct = ngx_http_cache_purge_content_type_xml;
+            resp_ct_size = ngx_http_cache_purge_content_type_xml_size;
+            resp_body = ngx_http_cache_purge_body_templ_xml;
+            resp_body_size = ngx_http_cache_purge_body_templ_xml_size;
+            break;
+
+        case NGX_REPONSE_TYPE_TEXT:
+            resp_ct = ngx_http_cache_purge_content_type_text;
+            resp_ct_size = ngx_http_cache_purge_content_type_text_size;
+            resp_body = ngx_http_cache_purge_body_templ_text;
+            resp_body_size = ngx_http_cache_purge_body_templ_text_size;
+            break;
+
+        default:
+        case NGX_REPONSE_TYPE_HTML:
+            resp_ct = ngx_http_cache_purge_content_type_html;
+            resp_ct_size = ngx_http_cache_purge_content_type_html_size;
+            resp_body = ngx_http_cache_purge_body_templ_html;
+            resp_body_size = ngx_http_cache_purge_body_templ_html_size;
+            break;
+    }
+
+    body_len = resp_body_size - 4 - 1;
+    r->headers_out.content_type.len = resp_ct_size - 1;
+    r->headers_out.content_type.data = (u_char *) resp_ct;
+
+    resp_tmpl_len = body_len + key[0].len + r->cache->file.name.len ;
+
+    buf = ngx_pcalloc(r->pool, resp_tmpl_len);
+    if (buf == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    p = ngx_snprintf(buf, resp_tmpl_len, resp_body , buf_keydata, r->cache->file.name.data);
+    if (p == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    len = body_len + key[0].len + r->cache->file.name.len;
+
     r->headers_out.status = NGX_HTTP_OK;
     r->headers_out.content_length_n = len;
 
@@ -1280,26 +1419,19 @@ ngx_http_cache_purge_send_response(ngx_http_request_t *r)
     if (b == NULL) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
+    
 
     out.buf = b;
     out.next = NULL;
 
-    b->last = ngx_cpymem(b->last, ngx_http_cache_purge_success_page_top,
-                         sizeof(ngx_http_cache_purge_success_page_top) - 1);
-    b->last = ngx_cpymem(b->last, "<br>Key : ", sizeof("<br>Key : ") - 1);
-    b->last = ngx_cpymem(b->last, key[0].data, key[0].len);
-    b->last = ngx_cpymem(b->last, CRLF "<br>Path: ",
-                         sizeof(CRLF "<br>Path: ") - 1);
-    b->last = ngx_cpymem(b->last, r->cache->file.name.data,
-                         r->cache->file.name.len);
-    b->last = ngx_cpymem(b->last, ngx_http_cache_purge_success_page_tail,
-                         sizeof(ngx_http_cache_purge_success_page_tail) - 1);
+    b->last = ngx_cpymem(b->last, buf, resp_tmpl_len);
     b->last_buf = 1;
 
     rc = ngx_http_send_header(r);
     if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
-       return rc;
+        return rc;
     }
+
 
     return ngx_http_output_filter(r, &out);
 }
@@ -1615,7 +1747,6 @@ ngx_http_cache_purge_merge_conf(ngx_http_cache_purge_conf_t *conf,
             conf->method = prev->method;
             conf->access = prev->access;
             conf->access6 = prev->access6;
-
         } else {
             conf->enable = 0;
         }
@@ -1655,6 +1786,8 @@ ngx_http_cache_purge_create_loc_conf(ngx_conf_t *cf)
     conf->uwsgi.enable = NGX_CONF_UNSET;
 # endif /* NGX_HTTP_UWSGI */
 
+    conf->resptype = NGX_CONF_UNSET_UINT;
+
     conf->conf = NGX_CONF_UNSET_PTR;
 
     return conf;
@@ -1680,6 +1813,8 @@ ngx_http_cache_purge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 # endif /* NGX_HTTP_UWSGI */
 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+
+    ngx_conf_merge_uint_value(conf->resptype, prev->resptype, NGX_REPONSE_TYPE_HTML);
 
 # if (NGX_HTTP_FASTCGI)
     ngx_http_cache_purge_merge_conf(&conf->fastcgi, &prev->fastcgi);

--- a/t/proxy1.t
+++ b/t/proxy1.t
@@ -92,10 +92,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /purge/proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy1.t
+++ b/t/proxy1.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket;
 
 repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 4 + 3 * 1);
+plan tests => repeat_each() * (blocks() * 4 + 3 * 1 + 1);
 
 our $http_config = <<'_EOC_';
     proxy_cache_path  /tmp/ngx_cache_purge_cache keys_zone=test_cache:10m;
@@ -79,7 +79,9 @@ PURGE /purge/proxy/passwd
 --- error_code: 200
 --- response_headers
 Content-Type: text/html
+Content-Length: 154
 --- response_body_like: Successful purge
+--- response_body_like: </html>$
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy1_vars.t
+++ b/t/proxy1_vars.t
@@ -94,10 +94,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /purge/proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy2.t
+++ b/t/proxy2.t
@@ -124,10 +124,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/
@@ -190,10 +190,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config_allowed
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy2_vars.t
+++ b/t/proxy2_vars.t
@@ -127,10 +127,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/
@@ -193,10 +193,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config_allowed
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy3.t
+++ b/t/proxy3.t
@@ -25,7 +25,7 @@ our $config = <<'_EOC_';
 
 
     location = /etc/passwd {
-        root               /var/www/html;
+        root               /;
     }
 _EOC_
 

--- a/t/proxy4.t
+++ b/t/proxy4.t
@@ -25,7 +25,7 @@ our $config = <<'_EOC_';
 
 
     location = /etc/passwd {
-        root               /var/www/html;
+        root               /;
     }
 _EOC_
 

--- a/t/resptype1.t
+++ b/t/resptype1.t
@@ -1,0 +1,245 @@
+# vi:filetype=perl
+
+use lib 'lib';
+use Test::Nginx::Socket;
+
+repeat_each(1);
+
+plan tests => repeat_each() * (blocks() * 4 + 3 * 1);
+
+our $http_config = <<'_EOC_';
+    proxy_cache_path  /tmp/ngx_cache_purge_cache keys_zone=test_cache:10m;
+    proxy_temp_path   /tmp/ngx_cache_purge_temp 1 2;
+_EOC_
+
+our $config = <<'_EOC_';
+
+    cache_purge_response_type json;
+
+    location /proxy {
+        proxy_pass         $scheme://127.0.0.1:$server_port/etc/passwd;
+        proxy_cache        test_cache;
+        proxy_cache_key    $uri$is_args$args;
+        proxy_cache_valid  3m;
+        add_header         X-Cache-Status $upstream_cache_status;
+    }
+
+    location ~ /purge(/.*) {
+        proxy_cache_purge           test_cache $1$is_args$args;
+        cache_purge_response_type   html;
+    }
+
+    location ~ /purge_json(/.*) {
+        proxy_cache_purge           test_cache $1$is_args$args;
+    }
+
+    location ~ /purge_xml(/.*) {
+        proxy_cache_purge           test_cache $1$is_args$args;
+        cache_purge_response_type   xml;
+    }
+
+    location ~ /purge_text(/.*) {
+        proxy_cache_purge           test_cache $1$is_args$args;
+        cache_purge_response_type   text;
+    }
+
+
+
+    location = /etc/passwd {
+        root               /;
+    }
+_EOC_
+
+worker_connections(128);
+no_shuffle();
+run_tests();
+
+no_diff();
+
+__DATA__
+
+=== TEST 1: prepare
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+
+
+=== TEST 2: get from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: HIT
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 5: < 0.8.3 or < 0.7.62
+
+
+
+=== TEST 3: purge from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+PURGE /purge/proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/html
+--- response_body_like: Successful purge
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+
+
+=== TEST 4: purge from empty cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+PURGE /purge/proxy/passwd
+--- error_code: 404
+--- response_headers
+Content-Type: text/html
+--- response_body_like: 404 Not Found
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+
+
+=== TEST 5: get from source
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: MISS
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 5: < 0.8.3 or < 0.7.62
+
+
+
+=== TEST 6: get from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+X-Cache-Status: HIT
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 5: < 0.8.3 or < 0.7.62
+
+=== TEST 7-prepare: prepare purge
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd?t=7
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+
+=== TEST 7: get a JSON response after purge from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+PURGE /purge_json/proxy/passwd?t=7
+--- error_code: 200
+--- response_headers
+Content-Type: application/json
+--- response_body_like: {\"Key\": \"\/proxy\/passwd\?t=7\",\"Path\": \"\/tmp\/ngx_cache_purge_cache\/
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+=== TEST 8-prepare: prepare purge
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd?t=8
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+
+=== TEST 8: get a XML response after purge from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+PURGE /purge_xml/proxy/passwd?t=8
+--- error_code: 200
+--- response_headers
+Content-Type: text/xml
+--- response_body_like: \<\?xml version=\"1.0\" encoding=\"UTF-8\"\?><status><Key><\!\[CDATA\[\/proxy\/passwd\?t=8\]\]><\/Key><Path><\!\[CDATA\[\/tmp\/ngx_cache_purge_cache\/
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+=== TEST 9-prepare: prepare purge
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+GET /proxy/passwd?t=9
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: root
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+
+=== TEST 9: get a TEXT response after purge from cache
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- request
+PURGE /purge_text/proxy/passwd?t=9
+--- error_code: 200
+--- response_headers
+Content-Type: text/plain
+--- response_body_like: Key
+--- timeout: 10
+--- no_error_log eval
+qr/\[(warn|error|crit|alert|emerg)\]/
+--- skip_nginx2: 4: < 0.8.3 or < 0.7.62
+
+

--- a/t/resptype1.t
+++ b/t/resptype1.t
@@ -112,10 +112,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /purge/proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/resptype1.t
+++ b/t/resptype1.t
@@ -178,7 +178,7 @@ PURGE /purge_json/proxy/passwd?t=7
 --- error_code: 200
 --- response_headers
 Content-Type: application/json
---- response_body_like: {\"Key\": \"\/proxy\/passwd\?t=7\",\"Path\": \"\/tmp\/ngx_cache_purge_cache\/
+--- response_body_like: {\"Key\": \"\/proxy\/passwd\?t=7\"
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/
@@ -207,7 +207,7 @@ PURGE /purge_xml/proxy/passwd?t=8
 --- error_code: 200
 --- response_headers
 Content-Type: text/xml
---- response_body_like: \<\?xml version=\"1.0\" encoding=\"UTF-8\"\?><status><Key><\!\[CDATA\[\/proxy\/passwd\?t=8\]\]><\/Key><Path><\!\[CDATA\[\/tmp\/ngx_cache_purge_cache\/
+--- response_body_like: \<\?xml version=\"1.0\" encoding=\"UTF-8\"\?><status><Key><\!\[CDATA\[\/proxy\/passwd\?t=8\]\]><\/Key>
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/


### PR DESCRIPTION
There was a recent change that changed the response sent from a cache purge, which removed the filename from the output, but not from the content-length calculation. This resulted in a Content-Length header that was too large by several bytes, and binary junk being printed when making a curl request, for example.